### PR TITLE
fix: delete url validation from ValidateStreak()

### DIFF
--- a/src/components/confirmations/CreateConfirmation.jsx
+++ b/src/components/confirmations/CreateConfirmation.jsx
@@ -15,16 +15,12 @@ export const CreateConfirmation = () => {
 
   const ValidateStreak = () => {
     eraseAlerts()
-    if (!name.trim().length) {
+    if (!name.trim()) {
       setNameAlert("Enter a name")
       return false
     }
-    if (!url.trim().length) {
+    if (!url.trim()) {
       setUrlAlert("Enter a URL")
-      return false
-    }
-    if (url.trim().length > 0 && !url.trim().includes("www.")) {
-      setUrlAlert("Enter a valid URL like www.example.com")
       return false
     }
     return true


### PR DESCRIPTION
## In this PR, I've:
- Created a `hotfix-avoid-url-validation` branch
- Deleted URL validation code, as some URLs doesn't have the "www." format, now the user can add any string as URL
- Problem: 
![image](https://github.com/user-attachments/assets/45475086-0651-48b3-9f4e-97a3d7a5484f)
