### PR TITLE
Edit streak

### DIFF
--- a/src/components/confirmations/CreateConfirmation.jsx
+++ b/src/components/confirmations/CreateConfirmation.jsx
@@ -31,7 +31,7 @@ export const CreateConfirmation = () => {
       const urlDomain = url.split(".")[1]
       const getDomainIcon = `https://icons.duckduckgo.com/ip3/${urlDomain}.com.ico`
       const id = Date.now()
-      store.addStreak({ id: id, name: name, image: getDomainIcon, url: url })
+      store.addStreak({ id: id, name: name.trim(), image: getDomainIcon, url: url })
       eraseData()
       eraseAlerts()
       store.toggleVisible2()

--- a/src/components/confirmations/CreateConfirmation.jsx
+++ b/src/components/confirmations/CreateConfirmation.jsx
@@ -13,7 +13,7 @@ export const CreateConfirmation = () => {
   const eraseData = () => (setName(""), setUrl(""))
   const eraseAlerts = () => (setNameAlert(""), setUrlAlert(""))
 
-  const ValidateStreak = () => {
+  const validateStreak = () => {
     eraseAlerts()
     if (!name.trim()) {
       setNameAlert("Enter a name")
@@ -27,7 +27,7 @@ export const CreateConfirmation = () => {
   }
 
   const addStreak = () => {
-    if (ValidateStreak()) {
+    if (validateStreak()) {
       const urlDomain = url.split(".")[1]
       const getDomainIcon = `https://icons.duckduckgo.com/ip3/${urlDomain}.com.ico`
       const id = Date.now()

--- a/src/components/confirmations/DeleteConfirmation.jsx
+++ b/src/components/confirmations/DeleteConfirmation.jsx
@@ -4,21 +4,15 @@ import './Confirmations.css'
 
 export const DeleteConfirmation = () => {
   const store = Store()
-  const visibility = store.visible3 ? "" : "hide"
-  const deleteStreak = () => {
-    store.deleteStreak()
-    store.setStreakIdToDelete(0)
-    store.toggleVisible3()
-  }
+  const streakNameToDelete = store.streaks.find(streak => streak.id === store.streakIdToDelete).name
 
   return (
-    <div className={`confirmations ${visibility}`}>
-      <h2>Are you sure to delete {store.streakNameToDelete}?</h2>
-      <button className='btn close-btn' onClick={() => store.toggleVisible3()}><CloseIcon /></button>
+    <div className={`confirmations`}>
+      <h2>Are you sure to delete {streakNameToDelete}?</h2>
+      <button className='btn close-btn' onClick={() => store.setStreakIdToDelete(null)}><CloseIcon /></button>
       <p className='warning'>You will lost your streak!</p>
       <div className='delete-cancel-btns'>
-        <button className='btn delete' onClick={deleteStreak}>DELETE</button>
-        <button className='btn cancel' onClick={() => store.toggleVisible3()}>CANCEL</button>
+        <button className='btn delete' onClick={() => store.deleteStreak()}>DELETE</button>
       </div >
     </div >
   )

--- a/src/components/confirmations/EditConfirmation.jsx
+++ b/src/components/confirmations/EditConfirmation.jsx
@@ -1,70 +1,27 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import CloseIcon from '@mui/icons-material/Close';
 import { Store } from '../../store/Store'
 import './Confirmations.css'
 
 export const EditConfirmation = () => {
   const store = Store()
-  const visibility = store.visible4 ? "" : "hide"
-  const [name, setName] = useState("")
-  const [url, setUrl] = useState("")
-  const [nameAlert, setNameAlert] = useState("")
-  const [urlAlert, setUrlAlert] = useState("")
-  const eraseData = () => (setName(""), setUrl(""))
-  const eraseAlerts = () => (setNameAlert(""), setUrlAlert(""))
+  const streakToEdit = store.streaks.find(streak => streak.id === store.streakIdToEdit)
+  const [name, setName] = useState(streakToEdit.name)
 
-  const ValidateStreak = () => {
-    eraseAlerts()
-    if (!name.trim().length) {
-      setNameAlert("Enter a name")
-      return false
-    }
-    if (!url.trim().length) {
-      setUrlAlert("Enter a URL")
-      return false
-    }
-    if (url.trim().length > 0 && !url.trim().includes("www.")) {
-      setUrlAlert("Enter a valid URL like www.example.com")
-      return false
-    }
-    return true
+  const saveEditedStreak = () => {
+    store.saveEditedStreak(name)
+    localStorage.setItem("streaks", JSON.stringify(store.streaks))
   }
-
-  const addStreak = () => {
-    if (ValidateStreak()) {
-      const urlDomain = url.split(".")[1]
-      const getDomainIcon = `https://icons.duckduckgo.com/ip3/${urlDomain}.com.ico`
-      const id = Date.now()
-      store.addStreak({ id: id, name: name, image: getDomainIcon, url: url })
-      eraseData()
-      eraseAlerts()
-      store.toggleVisible2()
-    }
-  }
-
-  const closeBtn = () => {
-    store.toggleVisible4()
-    eraseData()
-    eraseAlerts()
-  }
-
-  useEffect(() => localStorage.setItem("streaks", JSON.stringify(store.streaks)), [store.streaks])
 
   return (
-    <div className={`confirmations ${visibility}`}>
-      <h2>Edit Streak</h2>
-      <button className='btn close-btn' onClick={closeBtn}><CloseIcon /></button>
+    <div className={`confirmations`}>
+      <h2>Edit {streakToEdit.name} Streak</h2>
+      <button className='btn close-btn' onClick={() => store.setStreakIdToEdit(null)}><CloseIcon /></button>
       <div>
         <p>name</p>
         <input type="text" value={name} onChange={e => setName(e.target.value)} />
-        <span className='warning'>{nameAlert}</span>
       </div>
-      <div>
-        <p>url</p>
-        <input type="text" value={url} onChange={(e => setUrl(e.target.value))} />
-        <span className='warning'>{urlAlert}</span>
-      </div>
-      <button type="submit" className='btn create' onClick={addStreak}>CREATE</button>
-    </div >
+      <button type="submit" className='btn create' onClick={saveEditedStreak}>SAVE</button>
+    </div>
   )
 }

--- a/src/components/confirmations/EditConfirmation.jsx
+++ b/src/components/confirmations/EditConfirmation.jsx
@@ -20,7 +20,7 @@ export const EditConfirmation = () => {
 
   const saveEditedStreak = () => {
     if (validateStreak()) {
-      store.saveEditedStreak(name)
+      store.saveEditedStreak(name.trim())
       localStorage.setItem("streaks", JSON.stringify(store.streaks))
     }
   }

--- a/src/components/confirmations/EditConfirmation.jsx
+++ b/src/components/confirmations/EditConfirmation.jsx
@@ -7,10 +7,22 @@ export const EditConfirmation = () => {
   const store = Store()
   const streakToEdit = store.streaks.find(streak => streak.id === store.streakIdToEdit)
   const [name, setName] = useState(streakToEdit.name)
+  const [nameAlert, setNameAlert] = useState("")
+
+  const validateStreak = () => {
+    setNameAlert("")
+    if (!name.trim()) {
+      setNameAlert("Enter a name")
+      return false
+    }
+    return true
+  }
 
   const saveEditedStreak = () => {
-    store.saveEditedStreak(name)
-    localStorage.setItem("streaks", JSON.stringify(store.streaks))
+    if (validateStreak()) {
+      store.saveEditedStreak(name)
+      localStorage.setItem("streaks", JSON.stringify(store.streaks))
+    }
   }
 
   return (
@@ -20,6 +32,7 @@ export const EditConfirmation = () => {
       <div>
         <p>name</p>
         <input type="text" value={name} onChange={e => setName(e.target.value)} />
+        <span className='warning'>{nameAlert}</span>
       </div>
       <button type="submit" className='btn create' onClick={saveEditedStreak}>SAVE</button>
     </div>

--- a/src/components/confirmations/EditConfirmation.jsx
+++ b/src/components/confirmations/EditConfirmation.jsx
@@ -1,0 +1,70 @@
+import { useState, useEffect } from 'react'
+import CloseIcon from '@mui/icons-material/Close';
+import { Store } from '../../store/Store'
+import './Confirmations.css'
+
+export const EditConfirmation = () => {
+  const store = Store()
+  const visibility = store.visible4 ? "" : "hide"
+  const [name, setName] = useState("")
+  const [url, setUrl] = useState("")
+  const [nameAlert, setNameAlert] = useState("")
+  const [urlAlert, setUrlAlert] = useState("")
+  const eraseData = () => (setName(""), setUrl(""))
+  const eraseAlerts = () => (setNameAlert(""), setUrlAlert(""))
+
+  const ValidateStreak = () => {
+    eraseAlerts()
+    if (!name.trim().length) {
+      setNameAlert("Enter a name")
+      return false
+    }
+    if (!url.trim().length) {
+      setUrlAlert("Enter a URL")
+      return false
+    }
+    if (url.trim().length > 0 && !url.trim().includes("www.")) {
+      setUrlAlert("Enter a valid URL like www.example.com")
+      return false
+    }
+    return true
+  }
+
+  const addStreak = () => {
+    if (ValidateStreak()) {
+      const urlDomain = url.split(".")[1]
+      const getDomainIcon = `https://icons.duckduckgo.com/ip3/${urlDomain}.com.ico`
+      const id = Date.now()
+      store.addStreak({ id: id, name: name, image: getDomainIcon, url: url })
+      eraseData()
+      eraseAlerts()
+      store.toggleVisible2()
+    }
+  }
+
+  const closeBtn = () => {
+    store.toggleVisible4()
+    eraseData()
+    eraseAlerts()
+  }
+
+  useEffect(() => localStorage.setItem("streaks", JSON.stringify(store.streaks)), [store.streaks])
+
+  return (
+    <div className={`confirmations ${visibility}`}>
+      <h2>Edit Streak</h2>
+      <button className='btn close-btn' onClick={closeBtn}><CloseIcon /></button>
+      <div>
+        <p>name</p>
+        <input type="text" value={name} onChange={e => setName(e.target.value)} />
+        <span className='warning'>{nameAlert}</span>
+      </div>
+      <div>
+        <p>url</p>
+        <input type="text" value={url} onChange={(e => setUrl(e.target.value))} />
+        <span className='warning'>{urlAlert}</span>
+      </div>
+      <button type="submit" className='btn create' onClick={addStreak}>CREATE</button>
+    </div >
+  )
+}

--- a/src/components/grid/Grid.jsx
+++ b/src/components/grid/Grid.jsx
@@ -1,15 +1,17 @@
+import { Store } from '../../store/Store'
 import { CreateConfirmation } from '../confirmations/CreateConfirmation'
 import { EditConfirmation } from '../confirmations/EditConfirmation'
 import { DeleteConfirmation } from '../confirmations/DeleteConfirmation'
 import './Grid.css'
 
 export const Grid = () => {
+  const store = Store()
   return (
     <div className='grid'>
       <div className="grid-container"> 1 2 3</div>
       <CreateConfirmation />
-      <EditConfirmation />
-      <DeleteConfirmation />
+      {store.streakIdToEdit && <EditConfirmation />}
+      {store.streakIdToDelete && <DeleteConfirmation />}
     </div>
   )
 }

--- a/src/components/grid/Grid.jsx
+++ b/src/components/grid/Grid.jsx
@@ -1,4 +1,5 @@
 import { CreateConfirmation } from '../confirmations/CreateConfirmation'
+import { EditConfirmation } from '../confirmations/EditConfirmation'
 import { DeleteConfirmation } from '../confirmations/DeleteConfirmation'
 import './Grid.css'
 
@@ -7,6 +8,7 @@ export const Grid = () => {
     <div className='grid'>
       <div className="grid-container"> 1 2 3</div>
       <CreateConfirmation />
+      <EditConfirmation />
       <DeleteConfirmation />
     </div>
   )

--- a/src/components/streaks/Streak.css
+++ b/src/components/streaks/Streak.css
@@ -21,16 +21,24 @@
   border-radius: calc((1vw + 1vh)/3);
 }
 
-.streak .streak-delete-btn {
+.streak .streak-delete-btn,
+.streak .streak-edit-btn {
   width: 25%;
   aspect-ratio: 1 / 1;
   position: absolute;
   top: 0;
-  left: 0;
   border: none;
   display: flex;
   justify-content: center;
   align-items: center;
+}
+
+.streak .streak-delete-btn {
+  left: 0;
+}
+
+.streak .streak-edit-btn {
+  right: 0;
 }
 
 .streak span {

--- a/src/components/streaks/Streak.jsx
+++ b/src/components/streaks/Streak.jsx
@@ -14,7 +14,7 @@ export const Streak = ({ id, name, image, url }) => {
     store.setStreakIdToEdit(id)
     store.visible2 && store.toggleVisible2()
     store.visible3 && store.toggleVisible3()
-    store.toggleVisible4()
+    !store.visible4 && store.toggleVisible4()
   }
 
   const deleteStreak = () => {
@@ -23,7 +23,7 @@ export const Streak = ({ id, name, image, url }) => {
     store.setStreakIdToDelete(id)
     // show delete streak dialog and hide other dialogs
     store.visible2 && store.toggleVisible2()
-    store.toggleVisible3()
+    !store.visible3 && store.toggleVisible3()
     store.visible4 && store.toggleVisible4()
   }
 

--- a/src/components/streaks/Streak.jsx
+++ b/src/components/streaks/Streak.jsx
@@ -9,7 +9,12 @@ export const Streak = ({ id, name, image, url }) => {
   const [visible, setVisible] = useState('hide')
 
   const editStreak = () => {
-    // TODO
+    // here we aren't editing the streak, just setting the id to the streak that is going to be edited
+    // real edition of that streak takes place on edit confirmation dialog
+    store.setStreakIdToEdit(id)
+    store.visible2 && store.toggleVisible2()
+    store.visible3 && store.toggleVisible3()
+    store.toggleVisible4()
   }
 
   const deleteStreak = () => {
@@ -17,8 +22,9 @@ export const Streak = ({ id, name, image, url }) => {
     // real deletion of that streak takes place on delete confirmation dialog
     store.setStreakIdToDelete(id)
     // show delete streak dialog and hide other dialogs
-    !store.visible3 && store.toggleVisible3()
     store.visible2 && store.toggleVisible2()
+    store.toggleVisible3()
+    store.visible4 && store.toggleVisible4()
   }
 
   return (

--- a/src/components/streaks/Streak.jsx
+++ b/src/components/streaks/Streak.jsx
@@ -11,10 +11,10 @@ export const Streak = ({ id, name, image, url }) => {
   const editStreak = () => {
     // here we aren't editing the streak, just setting the id to the streak that is going to be edited
     // real edition of that streak takes place on edit confirmation dialog
-    store.setStreakIdToEdit(id)
     store.visible2 && store.toggleVisible2()
-    store.visible3 && store.toggleVisible3()
-    !store.visible4 && store.toggleVisible4()
+    // show edit streak dialog and hide other dialogs
+    store.setStreakIdToEdit(id)
+    store.setStreakIdToDelete(null)
   }
 
   const deleteStreak = () => {
@@ -23,8 +23,8 @@ export const Streak = ({ id, name, image, url }) => {
     store.setStreakIdToDelete(id)
     // show delete streak dialog and hide other dialogs
     store.visible2 && store.toggleVisible2()
-    !store.visible3 && store.toggleVisible3()
-    store.visible4 && store.toggleVisible4()
+    store.setStreakIdToEdit(null)
+    store.setStreakIdToDelete(id)
   }
 
   return (

--- a/src/components/streaks/Streak.jsx
+++ b/src/components/streaks/Streak.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/DeleteOutline';
 import { Store } from '../../store/Store'
 import './Streak.css'
@@ -6,6 +7,11 @@ import './Streak.css'
 export const Streak = ({ id, name, image, url }) => {
   const store = Store()
   const [visible, setVisible] = useState('hide')
+
+  const editStreak = () => {
+    // TODO
+  }
+
   const deleteStreak = () => {
     // here we aren't deleting the streak, just setting the id to the streak that is going to be deleted
     // real deletion of that streak takes place on delete confirmation dialog
@@ -20,7 +26,8 @@ export const Streak = ({ id, name, image, url }) => {
       <a className='streak-container' href={url} target="_blank" rel='noopener noreferrer'>
         <img className='streak-bg' src={image} alt={name} />
       </a>
-      <button className={`btn streak-delete-btn ${visible}`} onClick={deleteStreak}><DeleteIcon sx={{ fontSize: 'calc((1.5vw + 1.5vh)/1.5)' }}/></button>
+      <button className={`btn streak-edit-btn ${visible}`} onClick={editStreak}><EditIcon sx={{ fontSize: '1.5vw' }} /></button>
+      <button className={`btn streak-delete-btn ${visible}`} onClick={deleteStreak}><DeleteIcon sx={{ fontSize: '1.5vw' }} /></button>
       <span>{name}</span>
     </div>
   )

--- a/src/components/streaks/Streaks.jsx
+++ b/src/components/streaks/Streaks.jsx
@@ -12,6 +12,7 @@ export const Streaks = () => {
     // show add streak dialog and close other open dialogs
     store.toggleVisible2()
     store.visible3 && store.toggleVisible3()
+    store.visible4 && store.toggleVisible4()
   }
 
   return (

--- a/src/components/streaks/Streaks.jsx
+++ b/src/components/streaks/Streaks.jsx
@@ -17,6 +17,7 @@ export const Streaks = () => {
   return (
     <div className='streaks' onMouseEnter={() => setVisible(`${streaks.length < 10 ? '' : 'hide'}`)} onMouseLeave={() => setVisible('hide')} >
       <div className="streaks-list">
+        {streaks.map(e => (<Streak key={e.id} id={e.id} name={e.name} image={e.image} url={e.url} />))}
         <button className={`btn add-streak-btn ${visible}`} onClick={addStreak}>+</button>
       </div>
     </div>

--- a/src/components/streaks/Streaks.jsx
+++ b/src/components/streaks/Streaks.jsx
@@ -10,7 +10,7 @@ export const Streaks = () => {
 
   const addStreak = () => {
     // show add streak dialog and close other open dialogs
-    store.toggleVisible2()
+    !store.visible2 && store.toggleVisible2()
     store.visible3 && store.toggleVisible3()
     store.visible4 && store.toggleVisible4()
   }

--- a/src/components/streaks/Streaks.jsx
+++ b/src/components/streaks/Streaks.jsx
@@ -9,18 +9,14 @@ export const Streaks = () => {
   const [visible, setVisible] = useState('hide')
 
   const addStreak = () => {
-    // show add streak dialog and close other open dialogs
-    !store.visible2 && store.toggleVisible2()
-    store.visible3 && store.toggleVisible3()
-    store.visible4 && store.toggleVisible4()
+    !store.visible2 && store.toggleVisible2() // show create streak dialog
+    store.setStreakIdToEdit(null) // hide edit streak dialog
+    store.setStreakIdToDelete(null) // hide delete streak dialog
   }
 
   return (
     <div className='streaks' onMouseEnter={() => setVisible(`${streaks.length < 10 ? '' : 'hide'}`)} onMouseLeave={() => setVisible('hide')} >
       <div className="streaks-list">
-        {streaks.map(e => (
-          <Streak key={e.id} id={e.id} name={e.name} image={e.image} url={e.url} />
-        ))}
         <button className={`btn add-streak-btn ${visible}`} onClick={addStreak}>+</button>
       </div>
     </div>

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -4,25 +4,25 @@ import { devtools } from 'zustand/middleware'
 export const Store = create(devtools(set => ({
   visible1: true, // show or hide config main menu
   visible2: false, // show or hide create new streak dialog
-  toggleVisible1: () => set(state => ({ visible1: !state.visible1 })),
-  toggleVisible2: () => set(state => ({ visible2: !state.visible2 })),
+  toggleVisible1: () => set(state => ({ visible1: !state.visible1 }), false, 'toggleVisible1'),
+  toggleVisible2: () => set(state => ({ visible2: !state.visible2 }), false, 'toggleVisible2'),
 
   streaks: JSON.parse(localStorage.getItem("streaks")) || [],
-  addStreak: data => set(state => ({ streaks: [...state.streaks, data] })),
+  addStreak: data => set(state => ({ streaks: [...state.streaks, data] }), undefined, 'addStreak'),
 
   streakIdToEdit: null,
-  setStreakIdToEdit: id => set({ streakIdToEdit: id }),
+  setStreakIdToEdit: id => set({ streakIdToEdit: id }, undefined, 'setStreakIdToEdit'),
   saveEditedStreak: name => set(state => {
     const newStreaksArray = state.streaks
     const streakIndexToEdit = state.streaks.findIndex(streak => streak.id === state.streakIdToEdit)
     newStreaksArray[streakIndexToEdit].name = name
     return ({ streaks: newStreaksArray, streakIdToEdit: null })
-  }),
+  }, undefined, 'saveEditedStreak'),
 
   streakIdToDelete: null,
-  setStreakIdToDelete: id => set({ streakIdToDelete: id }),
+  setStreakIdToDelete: id => set({ streakIdToDelete: id }, undefined, 'setStreakIdToDelete'),
   deleteStreak: () => set(state => {
     const newStreaksArray = state.streaks.filter(obj => obj.id !== state.streakIdToDelete)
     return ({ streaks: newStreaksArray, streakIdToDelete: null })
-  }),
+  }, undefined, 'deleteStreak'),
 })))

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -4,23 +4,25 @@ import { devtools } from 'zustand/middleware'
 export const Store = create(devtools(set => ({
   visible1: true, // show or hide config main menu
   visible2: false, // show or hide create new streak dialog
-  visible3: false, // show or hide delete streak dialog
-  visible4: false, // show or hide edit streak dialog
   toggleVisible1: () => set(state => ({ visible1: !state.visible1 })),
   toggleVisible2: () => set(state => ({ visible2: !state.visible2 })),
-  toggleVisible3: () => set(state => ({ visible3: !state.visible3 })),
-  toggleVisible4: () => set(state => ({ visible4: !state.visible4 })),
 
   streaks: JSON.parse(localStorage.getItem("streaks")) || [],
   addStreak: data => set(state => ({ streaks: [...state.streaks, data] })),
 
   streakIdToEdit: null,
   setStreakIdToEdit: id => set({ streakIdToEdit: id }),
+  saveEditedStreak: name => set(state => {
+    const newStreaksArray = state.streaks
+    const streakIndexToEdit = state.streaks.findIndex(streak => streak.id === state.streakIdToEdit)
+    newStreaksArray[streakIndexToEdit].name = name
+    return ({ streaks: newStreaksArray, streakIdToEdit: null })
+  }),
 
   streakIdToDelete: null,
   setStreakIdToDelete: id => set({ streakIdToDelete: id }),
   deleteStreak: () => set(state => {
     const newStreaksArray = state.streaks.filter(obj => obj.id !== state.streakIdToDelete)
-    return ({ streaks: newStreaksArray })
+    return ({ streaks: newStreaksArray, streakIdToDelete: null })
   }),
 })))

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -5,14 +5,19 @@ export const Store = create(devtools(set => ({
   visible1: true, // show or hide config main menu
   visible2: false, // show or hide create new streak dialog
   visible3: false, // show or hide delete streak dialog
+  visible4: false, // show or hide edit streak dialog
   toggleVisible1: () => set(state => ({ visible1: !state.visible1 })),
   toggleVisible2: () => set(state => ({ visible2: !state.visible2 })),
   toggleVisible3: () => set(state => ({ visible3: !state.visible3 })),
+  toggleVisible4: () => set(state => ({ visible4: !state.visible4 })),
 
   streaks: JSON.parse(localStorage.getItem("streaks")) || [],
   addStreak: data => set(state => ({ streaks: [...state.streaks, data] })),
 
-  streakIdToDelete: 0,
+  streakIdToEdit: null,
+  setStreakIdToEdit: id => set({ streakIdToEdit: id }),
+
+  streakIdToDelete: null,
   setStreakIdToDelete: id => set({ streakIdToDelete: id }),
   deleteStreak: () => set(state => {
     const newStreaksArray = state.streaks.filter(obj => obj.id !== state.streakIdToDelete)

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
+import { addStreak, saveEditedStreak, deleteStreak } from './streaks'
 
 export const Store = create(devtools(set => ({
   visible1: true, // show or hide config main menu
@@ -8,21 +9,14 @@ export const Store = create(devtools(set => ({
   toggleVisible2: () => set(state => ({ visible2: !state.visible2 }), false, 'toggleVisible2'),
 
   streaks: JSON.parse(localStorage.getItem("streaks")) || [],
-  addStreak: data => set(state => ({ streaks: [...state.streaks, data] }), undefined, 'addStreak'),
+  // addStreak: data => set(state => ({ streaks: [...state.streaks, data] }), undefined, 'addStreak'),
+  addStreak: data => addStreak(data, set),
 
   streakIdToEdit: null,
   setStreakIdToEdit: id => set({ streakIdToEdit: id }, undefined, 'setStreakIdToEdit'),
-  saveEditedStreak: name => set(state => {
-    const newStreaksArray = state.streaks
-    const streakIndexToEdit = state.streaks.findIndex(streak => streak.id === state.streakIdToEdit)
-    newStreaksArray[streakIndexToEdit].name = name
-    return ({ streaks: newStreaksArray, streakIdToEdit: null })
-  }, undefined, 'saveEditedStreak'),
+  saveEditedStreak: name => saveEditedStreak(name, set),
 
   streakIdToDelete: null,
   setStreakIdToDelete: id => set({ streakIdToDelete: id }, undefined, 'setStreakIdToDelete'),
-  deleteStreak: () => set(state => {
-    const newStreaksArray = state.streaks.filter(obj => obj.id !== state.streakIdToDelete)
-    return ({ streaks: newStreaksArray, streakIdToDelete: null })
-  }, undefined, 'deleteStreak'),
+  deleteStreak: () => deleteStreak(set),
 })))

--- a/src/store/streaks.js
+++ b/src/store/streaks.js
@@ -1,0 +1,25 @@
+export const addStreak = (data, set) => {
+  set(state => ({
+    streaks: [...state.streaks, data]
+  }), undefined, 'toggleVisible1')
+}
+
+export const saveEditedStreak = (name, set) => {
+  set(state => {
+    const newStreaksArray = state.streaks
+    const streakIndexToEdit = state.streaks.findIndex(streak => streak.id === state.streakIdToEdit)
+    newStreaksArray[streakIndexToEdit].name = name
+    return ({
+      streaks: newStreaksArray, streakIdToEdit: null
+    })
+  }, undefined, 'saveEditedStreak')
+}
+
+export const deleteStreak = (set) => {
+  set(state => {
+    const newStreaksArray = state.streaks.filter(obj => obj.id !== state.streakIdToDelete)
+    return ({
+      streaks: newStreaksArray, streakIdToDelete: null
+    })
+  }, undefined, 'deleteStreak')
+}


### PR DESCRIPTION
## In this PR, I've:
- Created a `edit-streak` branch
- Added `edit` functionality that allows the user to edit the Streak's name property, but the URL can't be changed as the streak counter is meant to each URL
- Improved conditional rendering of components based on Store logic instead of `display: none` CSS 
- Added Zustand action names for better debugging on the Redux toolkit
- Split the complex code of some functions of the Store in a separate file
- Overview: 
![image](https://github.com/user-attachments/assets/22208c98-30b7-476a-b197-265fab16e6e1)
