### PR TITLE
Hotfix: streaks and shortcuts logos and layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -13,7 +13,7 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  gap: 8vh;
+  gap: 4vh;
 }
 
 .config-btn {

--- a/src/components/confirmations/CreateConfirmation.jsx
+++ b/src/components/confirmations/CreateConfirmation.jsx
@@ -33,7 +33,8 @@ export const CreateConfirmation = () => {
       const data = {
         id: Date.now(),
         name: name.trim(),
-        image: `https://icons.duckduckgo.com/ip3/${url.split(".")[1]}.com.ico`,
+        // image: `https://icons.duckduckgo.com/ip3/${url.split(".")[1]}.com.ico`,
+        image: `https://images.weserv.nl/?url=logo.clearbit.com/${url.split(".")[1]}.com`,
         url: url.trim()
       }
       if (store.streakOrShortcut === 'streak') {

--- a/src/components/confirmations/CreateConfirmation.jsx
+++ b/src/components/confirmations/CreateConfirmation.jsx
@@ -25,16 +25,23 @@ export const CreateConfirmation = () => {
       setUrlAlert("Enter a URL")
       return false
     }
+    try {
+      new URL(url).hostname
+    }
+    catch {
+      setUrlAlert("Invalid URL format (copy and paste from the address bar)")
+      return false
+    }
     return true
   }
 
   const add = () => {
     if (validate()) {
+      const domain = new URL(url.trim()).hostname
       const data = {
         id: Date.now(),
         name: name.trim(),
-        // image: `https://icons.duckduckgo.com/ip3/${url.split(".")[1]}.com.ico`,
-        image: `https://images.weserv.nl/?url=logo.clearbit.com/${url.split(".")[1]}.com`,
+        image: `https://images.weserv.nl/?url=logo.clearbit.com/${domain}`,
         url: url.trim()
       }
       if (store.streakOrShortcut === 'streak') {

--- a/src/components/streaks/Streak.css
+++ b/src/components/streaks/Streak.css
@@ -1,6 +1,5 @@
 .streak {
-  width: 6vw;
-  aspect-ratio: 10 / 13;
+  width: 5vw;
   display: flex;
   flex-direction: column;
   justify-content: space-between;

--- a/src/components/streaks/Streak.jsx
+++ b/src/components/streaks/Streak.jsx
@@ -36,7 +36,7 @@ export const Streak = ({ id, name, image, url, type }) => {
 
   return (
     <div className='streak' onMouseEnter={() => setVisible('')} onMouseLeave={() => setVisible('hide')}>
-      <a className='streak-container' href={url} target="_blank" rel='noopener noreferrer'>
+      <a className='streak-container' href={url}>
         <img className='streak-bg' src={image} alt={name}
           onError={e => {
             const domain = new URL(url).hostname

--- a/src/components/streaks/Streak.jsx
+++ b/src/components/streaks/Streak.jsx
@@ -37,7 +37,13 @@ export const Streak = ({ id, name, image, url, type }) => {
   return (
     <div className='streak' onMouseEnter={() => setVisible('')} onMouseLeave={() => setVisible('hide')}>
       <a className='streak-container' href={url} target="_blank" rel='noopener noreferrer'>
-        <img className='streak-bg' src={image} alt={name} />
+        <img className='streak-bg' src={image} alt={name}
+          onError={e => {
+            const domain = new URL(url).hostname
+            e.target.onerror = null
+            e.target.src = `https://icons.duckduckgo.com/ip3/${domain}.ico`
+          }}
+        />
       </a>
       <button className={`btn streak-edit-btn ${visible}`} onClick={edit}><EditIcon sx={{ fontSize: '1.5vw' }} /></button>
       <button className={`btn streak-delete-btn ${visible}`} onClick={deleteFn}><DeleteIcon sx={{ fontSize: '1.5vw' }} /></button>

--- a/src/components/streaks/Streaks.css
+++ b/src/components/streaks/Streaks.css
@@ -6,15 +6,14 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  column-gap: 2vw;
+  column-gap: 3.5vw;
 }
 
 .btn.add-streak-btn {
-  width: 6vw;
+  width: 5vw;
   aspect-ratio: 1/1;
   border: none;
   border-radius: calc((1vw + 1vh)/3);
-  margin-top: -20px;
   font-size: calc((1vw + 1vh)/0.3);
   display: flex;
   justify-content: center;
@@ -24,4 +23,8 @@
 .shortcuts {
   height: 100%;
   flex-wrap: wrap;
+}
+
+.invisible-filler {
+  visibility: hidden;
 }

--- a/src/components/streaks/Streaks.jsx
+++ b/src/components/streaks/Streaks.jsx
@@ -16,8 +16,8 @@ export const Streaks = ({ type }) => {
   }
 
   useEffect(() => {
-    if (type === 'streaks') { setVisible(`${streaksOrShortcutsArray.length < 11 ? '' : 'hide'}`) }
-    if (type === 'shortcuts') { setVisible(`${streaksOrShortcutsArray.length < 44 ? '' : 'hide'}`) }
+    if (type === 'streaks') { setVisible(`${streaksOrShortcutsArray.length < 10 ? '' : 'hide'}`) }
+    if (type === 'shortcuts') { setVisible(`${streaksOrShortcutsArray.length < 40 ? '' : 'hide'}`) }
   }, [type, streaksOrShortcutsArray.length])
 
   useEffect(() => {
@@ -28,7 +28,10 @@ export const Streaks = ({ type }) => {
   return (
     <div className={type} >
       {streaksOrShortcutsArray.map(e => (<Streak key={e.id} id={e.id} name={e.name} image={e.image} url={e.url} type={type} />))}
-      <button className={`btn add-streak-btn ${visible}`} onClick={add}>+</button>
+      <div className={`${visible} streak`}>
+        <button className={`btn add-streak-btn ${visible}`} onClick={add}>+</button>
+        <span className='invisible-filler'>Invisible filler</span>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## In this PR, I've:
- Created a `logos-icons` branch
- Used the Clearbit API to obtain the logos instead of the DuckDuckGo service, thanks to that logos of webpages now look clearer
- Maintain the DuckDuckGo service as a fallback 
- User should type the whole address instead of any string; this way, the Clearbit API will work fine, obtaining the logo
- Links open in the same tab instead of opening a new tab
- Reduce the maximum number of streaks to 10 and of shortcuts to 40
- Reduce the size of the streaks and shortcuts icons
- Improve overall layout of streaks and shortcuts
- Before / After: 
<img width="1920" height="1080" alt="before" src="https://github.com/user-attachments/assets/941db6ab-0e13-436d-a4bc-3092a1682d2d" />
<img width="1920" height="1080" alt="after" src="https://github.com/user-attachments/assets/7ab47907-3bc1-4454-aac3-424b0ff0c0d1" />
