### PR TITLE
Edit shortcut url

### DIFF
--- a/src/components/confirmations/EditConfirmation.jsx
+++ b/src/components/confirmations/EditConfirmation.jsx
@@ -11,12 +11,25 @@ export const EditConfirmation = () => {
   if (store.streakIdToEdit) streakOrShortcut = 'streak'
   if (store.shortcutIdToEdit) streakOrShortcut = 'shortcut'
   const [name, setName] = useState(streakOrShortcutToEdit.name)
+  const [url, setUrl] = useState(streakOrShortcutToEdit.url)
   const [nameAlert, setNameAlert] = useState("")
+  const [urlAlert, setUrlAlert] = useState("")
 
   const validate = () => {
     setNameAlert("")
     if (!name.trim()) {
       setNameAlert("Enter a name")
+      return false
+    }
+    if (!url.trim()) {
+      setUrlAlert("Enter a URL")
+      return false
+    }
+    try {
+      new URL(url).hostname
+    }
+    catch {
+      setUrlAlert("Invalid URL format (copy and paste from the address bar)")
       return false
     }
     return true
@@ -29,7 +42,13 @@ export const EditConfirmation = () => {
         localStorage.setItem("streaks", JSON.stringify(store.streaks))
       }
       if (streakOrShortcut === 'shortcut') {
-        store.saveEditedShortcut(name.trim())
+        const domain = new URL(url.trim()).hostname
+        const data = {
+          name: name.trim(),
+          image: `https://images.weserv.nl/?url=logo.clearbit.com/${domain}`,
+          url: url.trim()
+        }
+        store.saveEditedShortcut(data)
         localStorage.setItem("shortcuts", JSON.stringify(store.shortcuts))
       }
     }
@@ -53,6 +72,11 @@ export const EditConfirmation = () => {
         <input type="text" value={name} autoFocus onChange={e => setName(e.target.value)} />
         <span className='warning'>{nameAlert}</span>
       </div>
+      {(streakOrShortcut === 'shortcut') && <div>
+        <p>url</p>
+        <input type="text" value={url} onChange={e => setUrl(e.target.value)} />
+        <span className='warning'>{urlAlert}</span>
+      </div>}
       <button type="submit" className='btn create' onClick={saveEdited}>SAVE</button>
     </div>
   )

--- a/src/components/confirmations/EditConfirmation.jsx
+++ b/src/components/confirmations/EditConfirmation.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import CloseIcon from '@mui/icons-material/Close'
 import { Store } from '../../store/Store'
 import './Confirmations.css'
@@ -14,6 +14,11 @@ export const EditConfirmation = () => {
   const [url, setUrl] = useState(streakOrShortcutToEdit.url)
   const [nameAlert, setNameAlert] = useState("")
   const [urlAlert, setUrlAlert] = useState("")
+
+  useEffect(() => {
+    setName(streakOrShortcutToEdit.name)
+    setUrl(streakOrShortcutToEdit.url)
+  }, [streakOrShortcutToEdit])
 
   const validate = () => {
     setNameAlert("")

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -27,7 +27,7 @@ export const Store = create(devtools(set => ({
   addShortcut: data => addShortcut(data, set),
   shortcutIdToEdit: null,
   setShortcutIdToEdit: id => set({ shortcutIdToEdit: id }, undefined, 'setShortcutIdToEdit'),
-  saveEditedShortcut: name => saveEditedShortcut(name, set),
+  saveEditedShortcut: data => saveEditedShortcut(data, set),
   shortcutIdToDelete: null,
   setShortcutIdToDelete: id => set({ shortcutIdToDelete: id }, undefined, 'setShortcutIdToDelete'),
   deleteShortcut: () => deleteShortcut(set),

--- a/src/store/shortcuts.js
+++ b/src/store/shortcuts.js
@@ -4,11 +4,13 @@ export const addShortcut = (data, set) => {
   }), undefined, 'addShortcut')
 }
 
-export const saveEditedShortcut = (name, set) => {
+export const saveEditedShortcut = (data, set) => {
   set(state => {
     const newShortcutsArray = state.shortcuts
     const shortcutIndexToEdit = state.shortcuts.findIndex(shortcut => shortcut.id === state.shortcutIdToEdit)
-    newShortcutsArray[shortcutIndexToEdit].name = name
+    newShortcutsArray[shortcutIndexToEdit].name = data.name
+    newShortcutsArray[shortcutIndexToEdit].image = data.image
+    newShortcutsArray[shortcutIndexToEdit].url = data.url
     return ({
       shortcuts: newShortcutsArray, shortcutIdToEdit: null
     })
@@ -22,4 +24,4 @@ export const deleteShortcut = (set) => {
       shortcuts: newShortcutsArray, shortcutIdToDelete: null
     })
   }, undefined, 'deleteShortcut')
-}
+} 


### PR DESCRIPTION
## In this PR, I've:
- Created a `edit-shortcut-url` branch
- User can edit the URL from a saved shortcut, not just the name
- When changing the URL, the image or logo is also updated
- Before saving the edited URL, the same verifications are done as when creating the shortcut
- Before / After:
<img width="426" height="408" alt="before" src="https://github.com/user-attachments/assets/1b44e154-db53-4de5-bc25-c35d0cac69cc" />
<img width="426" height="407" alt="after" src="https://github.com/user-attachments/assets/d6f50fe2-b5ec-4338-8773-39f6cda25b50" />
